### PR TITLE
[add] - username displayed on login, delete confirm pop-up

### DIFF
--- a/client/public/styles.css
+++ b/client/public/styles.css
@@ -5,3 +5,10 @@
 .created-entry {
   height: 30px
 }
+
+.modal-container {
+  position: relative;
+}
+.modal-container .modal, .modal-container .modal-backdrop {
+  position: absolute;
+}

--- a/client/src/actions/setDeleteState.js
+++ b/client/src/actions/setDeleteState.js
@@ -1,0 +1,6 @@
+export const setDeleteState = (deleteClicked) => {      
+  return {
+    type: 'DELETE_CLICKED_SELECTOR',
+    payload: deleteClicked
+  }
+};

--- a/client/src/actions/setDeleteUserState.js
+++ b/client/src/actions/setDeleteUserState.js
@@ -1,0 +1,6 @@
+export const setDeleteUserState = (userToBeDeleted) => {      
+  return {
+    type: 'USER_TO_BE_DELETED_SELECTOR',
+    payload: userToBeDeleted
+  }
+};

--- a/client/src/components/GameEntry.jsx
+++ b/client/src/components/GameEntry.jsx
@@ -9,6 +9,7 @@ import { setLoginPage } from '../actions/setLoginPage';
 import { setEditState } from '../actions/setEditState';
 import { setUserGames } from '../actions/setUserGames';
 import { setDeleteState } from '../actions/setDeleteState';
+import { setDeleteUserState } from '../actions/setDeleteUserState';
 
 import { Modal, Alert, Popover, Col, Row, Button, Table, ListGroup, ListGroupItem, OverlayTrigger, ButtonToolbar } from 'react-bootstrap';
 
@@ -39,8 +40,9 @@ class GameEntry extends Component {
     this.props.setLoginPage('default');
   }
 
-  onDeleteHandler() {
-    axios.delete(`api/games/delete/${this.form.id}`)
+  onDeleteHandler(deletedUser) {
+    console.log('this guy is getting deleted.. inside of onDeleteHandler: ', deletedUser)
+    axios.delete(`api/games/delete/${deletedUser}`)
       .then((response) => {
         axios.get(`/api/games/fetch/user/${this.props.user}`)
           .then((response) => {
@@ -81,14 +83,14 @@ class GameEntry extends Component {
               style={{ width: "100px" }}
               type="button"
               bsStyle="danger"
-              onClick={() => { this.props.setDeleteState(true) }}
+              onClick={() => { console.log('this.props inside first delete button:',this.props); this.props.setDeleteState(true); this.props.setDeleteUserState(this.form.id)}}
             >
               Delete </Button>
 
             {this.props.deleteState ?
               <Modal
                 show={this.props.deleteState}
-                onHide={() => { !this.props.setDeleteState(false) }}
+                onHide={() => { this.props.setDeleteState(false); this.props.setDeleteUserState(null)}}
                
               >
                 <Modal.Header closeButton>
@@ -101,8 +103,8 @@ class GameEntry extends Component {
             </Modal.Body>
                 <Modal.Footer>
                   <ButtonToolbar>
-                  <Button style={{ width: "100px" }} bsStyle="danger" onClick={() => { this.props.setDeleteState(false); this.onDeleteHandler() }}>Delete</Button>
-                  <Button style={{ width: "100px" }} onClick={() => { this.props.setDeleteState(false) }}>Close</Button>
+                  <Button style={{ width: "100px" }} bsStyle="danger" onClick={() => { console.log('this.props inside second delete button: ',this.props); this.props.setDeleteState(false); this.onDeleteHandler.bind(this)(this.props.deleteUserState) }}>Delete</Button>
+                  <Button style={{ width: "100px" }} onClick={() => { this.props.setDeleteState(false); this.props.setDeleteUserState(null) }}>Close</Button>
                   </ButtonToolbar>
                 </Modal.Footer>
               </Modal>
@@ -124,7 +126,9 @@ const mapStateToProps = state => {
     location: state.location,
     setting: state.setting,
     user: state.user,
-    deleteState: state.deleteState
+    deleteState: state.deleteState,
+    deleteUserState: state.deleteUserState
+    
   }
 };
 
@@ -135,7 +139,8 @@ const matchDispatchToProps = dispatch => {
     setOption: setOption,
     setUserGames: setUserGames,
     setLoginPage: setLoginPage,
-    setDeleteState: setDeleteState
+    setDeleteState: setDeleteState,
+    setDeleteUserState: setDeleteUserState
   },
     dispatch);
 };

--- a/client/src/components/GameEntry.jsx
+++ b/client/src/components/GameEntry.jsx
@@ -41,11 +41,13 @@ class GameEntry extends Component {
   }
 
   onDeleteHandler(deletedUser) {
-    console.log('this guy is getting deleted.. inside of onDeleteHandler: ', deletedUser)
+    console.log('This person is definitely getting deleted from db: ', deletedUser)
     axios.delete(`api/games/delete/${deletedUser}`)
       .then((response) => {
         axios.get(`/api/games/fetch/user/${this.props.user}`)
           .then((response) => {
+            console.log('response.data from /api/games/fetch/user/${this.props.user}:', response.data)
+            //
             this.props.setUserGames(response.data);
           })
           .catch((err) => {
@@ -83,7 +85,7 @@ class GameEntry extends Component {
               style={{ width: "100px" }}
               type="button"
               bsStyle="danger"
-              onClick={() => { console.log('this.props inside first delete button:',this.props); this.props.setDeleteState(true); this.props.setDeleteUserState(this.form.id)}}
+              onClick={() => {this.props.setDeleteState(true); this.props.setDeleteUserState(this.form.id)}}
             >
               Delete </Button>
 
@@ -99,11 +101,11 @@ class GameEntry extends Component {
               </Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                  Are you sure you want to delete Game # {this.form.id}?
+                  Are you sure you want to delete Game # {this.props.deleteUserState}?
             </Modal.Body>
                 <Modal.Footer>
                   <ButtonToolbar>
-                  <Button style={{ width: "100px" }} bsStyle="danger" onClick={() => { console.log('this.props inside second delete button: ',this.props); this.props.setDeleteState(false); this.onDeleteHandler.bind(this)(this.props.deleteUserState) }}>Delete</Button>
+                  <Button style={{ width: "100px" }} bsStyle="danger" onClick={() => {this.props.setDeleteState(false); this.onDeleteHandler.bind(this)(this.props.deleteUserState) }}>Delete</Button>
                   <Button style={{ width: "100px" }} onClick={() => { this.props.setDeleteState(false); this.props.setDeleteUserState(null) }}>Close</Button>
                   </ButtonToolbar>
                 </Modal.Footer>

--- a/client/src/components/GameEntry.jsx
+++ b/client/src/components/GameEntry.jsx
@@ -86,10 +86,10 @@ class GameEntry extends Component {
               Delete </Button>
 
             {this.props.deleteState ?
-              <div className="modal-container" style={{ height: 200, position: 'absolute' }}>
               <Modal
                 show={this.props.deleteState}
-                onHide={() => { !this.props.deleteState }}
+                onHide={() => { !this.props.setDeleteState(false) }}
+               
               >
                 <Modal.Header closeButton>
                   <Modal.Title>
@@ -97,24 +97,15 @@ class GameEntry extends Component {
               </Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                  Are you sure you want to delete Game: {this.form.id} from User: {this.props.user}
+                  Are you sure you want to delete Game # {this.form.id}?
             </Modal.Body>
                 <Modal.Footer>
                   <ButtonToolbar>
-                  <Button bsStyle="danger" onClick={() => { this.props.setDeleteState(false); this.onDeleteHandler() }}>Delete</Button>
-                  <Button onClick={() => { this.props.setDeleteState(false) }}>Close</Button>
+                  <Button style={{ width: "100px" }} bsStyle="danger" onClick={() => { this.props.setDeleteState(false); this.onDeleteHandler() }}>Delete</Button>
+                  <Button style={{ width: "100px" }} onClick={() => { this.props.setDeleteState(false) }}>Close</Button>
                   </ButtonToolbar>
                 </Modal.Footer>
               </Modal>
-              </div>
-
-
-
-
-
-
-
-
               : null}
 
           </ButtonToolbar>

--- a/client/src/components/GameEntry.jsx
+++ b/client/src/components/GameEntry.jsx
@@ -8,14 +8,16 @@ import { setOption } from '../actions/setOption';
 import { setLoginPage } from '../actions/setLoginPage';
 import { setEditState } from '../actions/setEditState';
 import { setUserGames } from '../actions/setUserGames';
-import { Alert, Popover, Col, Row, Button, Table, ListGroup, ListGroupItem, OverlayTrigger, ButtonToolbar } from 'react-bootstrap';
+import { setDeleteState } from '../actions/setDeleteState';
+
+import { Modal, Alert, Popover, Col, Row, Button, Table, ListGroup, ListGroupItem, OverlayTrigger, ButtonToolbar } from 'react-bootstrap';
 
 
 class GameEntry extends Component {
   constructor(prop) {
     super(prop);
     console.log('this is this.game', prop.game);
-    
+
     this.form = {
       id: prop.game.id,
       sport: prop.game.sport,
@@ -69,18 +71,52 @@ class GameEntry extends Component {
 
           <ButtonToolbar>
             <Button
-              style={{ width: "100px"}}
+              style={{ width: "100px" }}
               type="button"
               bsStyle="primary"
               onClick={this.onEditHandler.bind(this)}
             >Edit</Button>
 
             <Button
-              style={{ width: "100px"}}
+              style={{ width: "100px" }}
               type="button"
               bsStyle="danger"
-              onClick={this.onDeleteHandler.bind(this)}
-            >Delete</Button>
+              onClick={() => { this.props.setDeleteState(true) }}
+            >
+              Delete </Button>
+
+            {this.props.deleteState ?
+              <div className="modal-container" style={{ height: 200, position: 'absolute' }}>
+              <Modal
+                show={this.props.deleteState}
+                onHide={() => { !this.props.deleteState }}
+              >
+                <Modal.Header closeButton>
+                  <Modal.Title>
+                    Warning!
+              </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                  Are you sure you want to delete Game: {this.form.id} from User: {this.props.user}
+            </Modal.Body>
+                <Modal.Footer>
+                  <ButtonToolbar>
+                  <Button bsStyle="danger" onClick={() => { this.props.setDeleteState(false); this.onDeleteHandler() }}>Delete</Button>
+                  <Button onClick={() => { this.props.setDeleteState(false) }}>Close</Button>
+                  </ButtonToolbar>
+                </Modal.Footer>
+              </Modal>
+              </div>
+
+
+
+
+
+
+
+
+              : null}
+
           </ButtonToolbar>
 
         </ListGroup>
@@ -96,7 +132,8 @@ const mapStateToProps = state => {
     edit: state.edit,
     location: state.location,
     setting: state.setting,
-    user: state.user
+    user: state.user,
+    deleteState: state.deleteState
   }
 };
 
@@ -106,7 +143,8 @@ const matchDispatchToProps = dispatch => {
     setGameSetting: setGameSetting,
     setOption: setOption,
     setUserGames: setUserGames,
-    setLoginPage: setLoginPage
+    setLoginPage: setLoginPage,
+    setDeleteState: setDeleteState
   },
     dispatch);
 };

--- a/client/src/components/Navi.jsx
+++ b/client/src/components/Navi.jsx
@@ -42,36 +42,36 @@ class Navi extends Component {
           {/* === CREATE BUTTON === */}
 
           <NavItem>
-          <a href=""
-            onClick={(e) => {
-              e.preventDefault()
-              if (this.props.user) {
-                this.props.setGameSetting({
-                  id: '',
-                  sport: '',
-                  max: '',
-                  start: '',
-                  end: '',
-                  competitive: false,
-                  notes: '',
-                  address: '',
-                  coordinates: '',
-                  UserId: ''
-                });
-                this.props.setEditState(false);
-                this.props.setOption('');
-                console.log('hello world');
-                this.props.setOption('create');
-                this.props.setLoginPage('default')
-              } else {
-                this.props.setLoginPage('login')
-              }
-            }}
-            className="navigation"
-          >
-            Create
+            <a href=""
+              onClick={(e) => {
+                e.preventDefault()
+                if (this.props.user) {
+                  this.props.setGameSetting({
+                    id: '',
+                    sport: '',
+                    max: '',
+                    start: '',
+                    end: '',
+                    competitive: false,
+                    notes: '',
+                    address: '',
+                    coordinates: '',
+                    UserId: ''
+                  });
+                  this.props.setEditState(false);
+                  this.props.setOption('');
+                  console.log('hello world');
+                  this.props.setOption('create');
+                  this.props.setLoginPage('default')
+                } else {
+                  this.props.setLoginPage('login')
+                }
+              }}
+              className="navigation"
+            >
+              Create
           </a>
-        </NavItem>
+          </NavItem>
 
           {/* === VIEW BUTTON === */}
 
@@ -85,7 +85,7 @@ class Navi extends Component {
                 } else {
                   this.props.setLoginPage('login')
                 }
-                
+
               }}
               className="navigation"
             >
@@ -96,76 +96,80 @@ class Navi extends Component {
           {/* === SIGNUP BUTTON === */}
           {
             !this.props.user
-            ?
-            <NavItem>
-              <a href=""
-                onClick={(e) => {
-                  e.preventDefault()
-                  this.props.setLoginPage('signup')
-                }}
-                className="navigation"
-              >
-                Sign Up
+              ?
+              <NavItem>
+                <a href=""
+                  onClick={(e) => {
+                    e.preventDefault()
+                    this.props.setLoginPage('signup')
+                  }}
+                  className="navigation"
+                >
+                  Sign Up
               </a>
-            </NavItem>
-            :
-            null
+              </NavItem>
+              :
+              null
           }
 
           {/* === LOGIN/LOGOUT BUTTON === */}
 
           {
             !this.props.user
-           
-            ?
-            
-            <NavItem>
-              <a href=""
-                onClick={
-                  (e) => {
+
+              ?
+
+              <NavItem>
+                <a href=""
+                  onClick={
+                    (e) => {
+                      e.preventDefault()
+                      this.props.setLoginPage('login')
+                    }}
+                  className="navigation"
+                >
+                  Login
+              </a>
+              </NavItem>
+
+              :
+
+              <NavItem>
+                <a href=""
+                  onClick={(e) => {
                     e.preventDefault()
-                    this.props.setLoginPage('login')
-                  }}
-                className="navigation"
-              >
-                Login
-              </a>
-            </NavItem>
 
-            :
-
-            <NavItem>
-              <a href=""
-                onClick={(e) => {
-                  e.preventDefault()
-
-                  axios.get('/api/user/logout')
-                    .then((data) => {
-                      window.localStorage.removeItem('token')
-                      window.localStorage.removeItem('username')
-                      this.props.setUser(null)
-                      this.props.setUserGames(null)
-                      this.props.setLoginPage('default')
-                      this.props.setOption('search')
-                      console.log('Data:', data.data.message)
-                    })
-                    .catch((err) => {
-                      console.log('Error logging out', err)
-                    })
+                    axios.get('/api/user/logout')
+                      .then((data) => {
+                        window.localStorage.removeItem('token')
+                        window.localStorage.removeItem('username')
+                        this.props.setUser(null)
+                        this.props.setUserGames(null)
+                        this.props.setLoginPage('default')
+                        this.props.setOption('search')
+                        console.log('Data:', data.data.message)
+                      })
+                      .catch((err) => {
+                        console.log('Error logging out', err)
+                      })
                   }
-                }
-                className="navigation"
-              >
-                Log Out
+                  }
+                  className="navigation"
+                >
+                  Log Out
               </a>
-            </NavItem>
+              </NavItem>
           }
-          
-          
-          
-          
 
         </Nav>
+        {!this.props.user ? null :
+          <Nav pullRight>
+            <NavItem>
+              {this.props.user}
+            </NavItem>
+          </Nav>
+        }
+
       </Navbar>
     )
   }

--- a/client/src/reducers/deleteState.js
+++ b/client/src/reducers/deleteState.js
@@ -1,0 +1,8 @@
+export default function (state=false, action) {
+  switch (action.type) {
+    case 'DELETE_CLICKED_SELECTOR':
+      return action.payload;
+      break;
+  }
+  return state;
+}

--- a/client/src/reducers/deleteUserState.js
+++ b/client/src/reducers/deleteUserState.js
@@ -1,6 +1,6 @@
 export default function (state=null, action) {
   switch (action.type) {
-    case 'DELETE_CLICKED_SELECTOR':
+    case 'USER_TO_BE_DELETED_SELECTOR':
       return action.payload;
       break;
   }

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -10,6 +10,7 @@ import User from './user';
 import EditState from './editState';
 import UserList from './userList';
 import DeleteState from './deleteState';
+import DeleteUserState from './deleteUserState';
 
 /*
  * We combine all reducers into a single object before updated data is dispatched (sent) to store
@@ -27,7 +28,8 @@ const allReducers = combineReducers({
   user: User,
   edit:EditState,
   userList: UserList,
-  deleteState: DeleteState
+  deleteState: DeleteState,
+  deleteUserState: DeleteUserState
 });
 
 export default allReducers

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -9,6 +9,7 @@ import UserGame from './userGame';
 import User from './user';
 import EditState from './editState';
 import UserList from './userList';
+import DeleteState from './deleteState';
 
 /*
  * We combine all reducers into a single object before updated data is dispatched (sent) to store
@@ -25,7 +26,8 @@ const allReducers = combineReducers({
   games: UserGame,
   user: User,
   edit:EditState,
-  userList: UserList
+  userList: UserList,
+  deleteState: DeleteState
 });
 
 export default allReducers


### PR DESCRIPTION
[Change-Log]
- username is now displayed when you are logged in
- upon clicking 'delete', the user is prompted if they really want to delete the game or not.

[Notes]
- I had to create two "store" states in order to hold whether or not the pop-up should be displayed, and which user should be deleted.
- Issue still exists where upon deleting a game, client-side rerenders as if the last game of your list was deleted. However, the correct game was deleted which can be seen in the database, or if you refresh the page. This might be an async issue with how quickly we are deleting from the db and then pulling new data from the db.